### PR TITLE
Migrate back to using upstream storybook-branch-switcher addon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "redux-thunk": "~2.3.0",
         "storybook": "^8.3.2",
         "storybook-addon-remix-react-router": "^3.0.0",
-        "storybook-branch-switcher": "github:patcon/storybook-branch-switcher#patcon/dev"
+        "storybook-branch-switcher": "^0.5.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7063,10 +7063,10 @@
       }
     },
     "node_modules/storybook-branch-switcher": {
-      "version": "0.4.1",
-      "resolved": "git+ssh://git@github.com/patcon/storybook-branch-switcher.git#634b16cda6408011f9af991178ed9934b1cf2081",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/storybook-branch-switcher/-/storybook-branch-switcher-0.5.0.tgz",
+      "integrity": "sha512-zbnNo3/KaCw5rIQqKL4NQ7I7srLqBKHH8H7t34V6wDGkrinkWevb40sGp9XyzID9WHAbbpmmZZJPqm7+Y2gtHA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@storybook/icons": "1.2.12",
         "zx": "^8.1.9"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "redux-thunk": "~2.3.0",
     "storybook": "^8.3.2",
     "storybook-addon-remix-react-router": "^3.0.0",
-    "storybook-branch-switcher": "github:patcon/storybook-branch-switcher#patcon/dev"
+    "storybook-branch-switcher": "^0.5.0"
   },
   "dependencies": {
     "@react-spring/web": "^9.7.4",


### PR DESCRIPTION
My PRs were merged, so going back to using mainline release instead of `patcon/dev` branch with our PRs added.