### PR TITLE
Implement accessible radix tabs in V2 components

### DIFF
--- a/.storybook/decorators.js
+++ b/.storybook/decorators.js
@@ -14,6 +14,26 @@ export const withThemeUi = (Story) => (
   </ThemeProvider>
 )
 
+const customParticipationTheme = Object.assign({}, compdemAdminTheme)
+customParticipationTheme.buttons["secondary"] = {
+  color: 'darkGray',
+  bg: 'lightGray',
+  fontFamily: 'body',
+  cursor: 'pointer'
+}
+customParticipationTheme["letterSpacings"] = {
+  button: 0.75,
+}
+customParticipationTheme.colors["polisBlue"] = "#03a9f4"
+customParticipationTheme.colors["darkGray"] = "rgb(100,100,100)"
+customParticipationTheme.colors["lightGray"] = "rgb(235,235,235)"
+
+export const withParticipationThemeUi = (Story) => (
+  <ThemeProvider theme={customParticipationTheme}>
+    <Story />
+  </ThemeProvider>
+)
+
 export const withDelibThemeUi = (Story) => (
   <ThemeProvider theme={haiDelibTheme}>
     <Story />

--- a/.storybook/decorators.js
+++ b/.storybook/decorators.js
@@ -16,7 +16,10 @@ export const withThemeUi = (Story) => (
 
 const customParticipationTheme = Object.assign({}, compdemAdminTheme)
 customParticipationTheme.fonts.body = "Arial"
-customParticipationTheme.buttons["secondary"] = {
+customParticipationTheme.buttons.primary.border = 0
+customParticipationTheme.buttons.primary.borderRadius = 4
+customParticipationTheme.buttons.secondary = {
+  ...customParticipationTheme.buttons.primary,
   color: 'darkGray',
   bg: 'lightGray',
   fontFamily: 'body',

--- a/.storybook/decorators.js
+++ b/.storybook/decorators.js
@@ -15,6 +15,7 @@ export const withThemeUi = (Story) => (
 )
 
 const customParticipationTheme = Object.assign({}, compdemAdminTheme)
+customParticipationTheme.fonts.body = "Arial"
 customParticipationTheme.buttons["secondary"] = {
   color: 'darkGray',
   bg: 'lightGray',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@radix-ui/react-tabs": "^1.1.1",
         "@react-spring/web": "^9.7.4",
         "color": "~4.2.3",
         "d3-force": "~1.2.1",
@@ -980,6 +981,289 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA=="
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.0.tgz",
+      "integrity": "sha512-GZsZslMJEyo1VKm5L1ZJY8tGDxZNPAoUeQUIbKeJfoi7Q4kmig5AsgLMYYuyYbfjd8fBmFORAIwYAkXMnXZgZw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
+      "integrity": "sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.1.tgz",
+      "integrity": "sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz",
+      "integrity": "sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-collection": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
+      "integrity": "sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.1.tgz",
+      "integrity": "sha512-3GBUDmP2DvzmtYLMsHmpA1GtR46ZDZ+OreXM/N+kkQJOPIgytFWWTfDQmBQKBvaFS0Vno0FktdbVzN28KGrMdw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-roving-focus": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-spring/animated": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "storybook-branch-switcher": "^0.5.0"
   },
   "dependencies": {
+    "@radix-ui/react-tabs": "^1.1.1",
     "@react-spring/web": "^9.7.4",
     "color": "~4.2.3",
     "d3-force": "~1.2.1",

--- a/stories/2.OurComponents.mdx
+++ b/stories/2.OurComponents.mdx
@@ -18,7 +18,7 @@ As a helpful resource, here is a summary of existing components (each a **clicka
 
 - <LinkTo kind="compdem/client-participation/CivicTechTO/CurateV2" story="Interactive">`CurateV2`</LinkTo>
   (Replaces <LinkTo kind="compdem/client-participation/Curate" story="Interactive">`Curate`</LinkTo>)
-- <LinkTo kind="compdem/client-participation/CivicTechTO/TidCarouselV2" story="Interactive">`TidCarouselV2`</LinkTo>
+- <LinkTo kind="compdem/client-participation/CivicTechTO/TidCarouselV2Animated" story="Interactive">`TidCarouselV2Animated`</LinkTo>
   and <LinkTo kind="compdem/client-participation/CivicTechTO/TidCarouselV2Static" story="Interactive">`TidCarouselV2Static`</LinkTo>
   (Replaces <LinkTo kind="compdem/client-participation/TidCarousel" story="Interactive">`TidCarousel`</LinkTo>)
 - <LinkTo kind="compdem/client-participation/CivicTechTO/SelectionWidgetV2" story="Interactive">`SelectionWidgetV2`</LinkTo>

--- a/stories/compdem/client-participation/CivicTechTO/CurateV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/CurateV2.js
@@ -4,17 +4,18 @@ import { jsx, Box } from 'theme-ui'
 import React from 'react'
 import * as globals from '../../../../codebases/compdem/client-participation/vis2/components/globals'
 
-export const CurateV2Button = React.forwardRef(({isSelected, onCurateButtonClick, style, children}, ref) => {
-  const buttonStyle = {
-    ...style,
-    fontSize: 14,
-    height: 35,
-    letterSpacing: 0.75,
-    variant: isSelected ? "buttons.primary" : "buttons.secondary",
-    textShadow: isSelected ? "0 0 .65px #fff" : null,
+export const CurateV2Button = React.forwardRef(({isSelected, handleClick, style, children, ...rest}, ref) => {
+  const styles = {
+    button: {
+      ...style,
+      fontSize: 14,
+      letterSpacing: 0.75,
+      variant: isSelected ? "buttons.primary" : "buttons.secondary",
+      textShadow: isSelected ? "0 0 .65px #fff" : null,
+    },
   }
   return (
-    <Box as="button" ref={ref} sx={buttonStyle} onClick={onCurateButtonClick}>
+    <Box as="button" ref={ref} sx={styles.button} onClick={handleClick} {...rest}>
       {children}
     </Box>
   )
@@ -35,12 +36,14 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
       gap: "5px",
     },
     groupButton: {
+      height: 35,
       flex: 1,
     },
     majorityContainer: {
       flex: [1, "1 1 33.333%"],
     },
     majorityButton: {
+      height: 35,
       width: "100%",
     },
   }
@@ -50,7 +53,7 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
     <div sx={styles.container}>
       <div sx={styles.majorityContainer}>
         <CurateV2Button
-          onCurateButtonClick={() => handleCurateButtonClick(globals.tidCuration.majority)}
+          handleClick={() => handleCurateButtonClick(globals.tidCuration.majority)}
           isSelected={selectedTidCuration === globals.tidCuration.majority}
           style={styles.majorityButton}
           children="Diverse Majority Opinion"
@@ -60,7 +63,7 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
         {groups.slice(0, GROUP_COUNT).map((groupLabel, index) => (
           <CurateV2Button
             key={groupLabel}
-            onCurateButtonClick={() => handleCurateButtonClick(index)}
+            handleClick={() => handleCurateButtonClick(index)}
             isSelected={selectedTidCuration === index}
             style={styles.groupButton}
             children={groupLabel}

--- a/stories/compdem/client-participation/CivicTechTO/CurateV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/CurateV2.js
@@ -53,7 +53,7 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
   return(
     isAccessible 
       ? (
-        <Tabs.Root defaultValue="group-majority" activationMode="manual">
+        <Tabs.Root value={`group-${selectedTidCuration}`} activationMode="manual">
           <Tabs.List aria-label="Groups" sx={styles.container}>
             <div sx={styles.majorityContainer}>
               <Tabs.Trigger value="group-majority" asChild>

--- a/stories/compdem/client-participation/CivicTechTO/CurateV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/CurateV2.js
@@ -22,7 +22,7 @@ export const CurateV2Button = React.forwardRef(({isSelected, handleClick, style,
   )
 })
 
-const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math}) => {
+const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math, isAccessible = false}) => {
   const GROUP_COUNT = math["group-clusters"].length
   const styles = {
     container: {
@@ -51,35 +51,59 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
   const groups = ['A', 'B', 'C', 'D', 'E']
   
   return(
-    // <div>
-      <Tabs.Root defaultValue="group-majority" activationMode="manual">
-        <Tabs.List aria-label="Groups" sx={styles.container}>
-          <div sx={styles.majorityContainer}>
-            <Tabs.Trigger value="group-majority" asChild>
-              <CurateV2Button
-                handleClick={() => handleCurateButtonClick(globals.tidCuration.majority)}
-                isSelected={selectedTidCuration === globals.tidCuration.majority}
-                style={styles.majorityButton}
-                children="Diverse Majority Opinion"
-              />
-            </Tabs.Trigger>
-            </div>
-          <div sx={styles.groupContainer}>
-            {groups.slice(0, GROUP_COUNT).map((groupLabel, index) => (
-              <Tabs.Trigger key={index} value={`group-${index}`} asChild>
+    isAccessible 
+      ? (
+        <Tabs.Root defaultValue="group-majority" activationMode="manual">
+          <Tabs.List aria-label="Groups" sx={styles.container}>
+            <div sx={styles.majorityContainer}>
+              <Tabs.Trigger value="group-majority" asChild>
                 <CurateV2Button
-                  key={groupLabel}
-                  handleClick={() => handleCurateButtonClick(index)}
-                  isSelected={selectedTidCuration === index}
-                  style={styles.groupButton}
-                  children={groupLabel}
+                  handleClick={() => handleCurateButtonClick(globals.tidCuration.majority)}
+                  isSelected={selectedTidCuration === globals.tidCuration.majority}
+                  style={styles.majorityButton}
+                  children="Diverse Majority Opinion"
                 />
               </Tabs.Trigger>
+              </div>
+            <div sx={styles.groupContainer}>
+              {groups.slice(0, GROUP_COUNT).map((groupLabel, index) => (
+                <Tabs.Trigger key={index} value={`group-${index}`} asChild>
+                  <CurateV2Button
+                    key={groupLabel}
+                    handleClick={() => handleCurateButtonClick(index)}
+                    isSelected={selectedTidCuration === index}
+                    style={styles.groupButton}
+                    children={groupLabel}
+                  />
+                </Tabs.Trigger>
+              ))}
+            </div>
+          </Tabs.List>
+        </Tabs.Root>
+      )
+      : (
+        <div sx={styles.container}>
+          <div sx={styles.majorityContainer}>
+            <CurateV2Button
+              handleClick={() => handleCurateButtonClick(globals.tidCuration.majority)}
+              isSelected={selectedTidCuration === globals.tidCuration.majority}
+              style={styles.majorityButton}
+              children="Diverse Majority Opinion"
+            />
+          </div>
+          <div sx={styles.groupContainer}>
+            {groups.slice(0, GROUP_COUNT).map((groupLabel, index) => (
+              <CurateV2Button
+                key={groupLabel}
+                handleClick={() => handleCurateButtonClick(index)}
+                isSelected={selectedTidCuration === index}
+                style={styles.groupButton}
+                children={groupLabel}
+              />
             ))}
           </div>
-        </Tabs.List>
-      </Tabs.Root>
-    // </div>
+        </div>
+      )
   )
 }
 

--- a/stories/compdem/client-participation/CivicTechTO/CurateV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/CurateV2.js
@@ -1,46 +1,44 @@
+/** @jsx jsx */
+import { jsx, Box } from 'theme-ui'
+
 import React from 'react'
 import * as globals from '../../../../codebases/compdem/client-participation/vis2/components/globals'
 
-export const CurateV2Button = ({isSelected, onCurateButtonClick, style, children}) => {
-  const colors = {
-    polisBlue: "#03a9f4",
-    darkGray: "rgb(100,100,100)",
-    lightGray: "rgb(235,235,235)",
-  }
+export const CurateV2Button = React.forwardRef(({isSelected, onCurateButtonClick, style, children}, ref) => {
   const buttonStyle = {
     ...style,
-    border: 0,
-    cursor: "pointer",
-    borderRadius: 4,
     fontSize: 14,
-    padding: "6px 12px",
+    height: 35,
     letterSpacing: 0.75,
-    // fontWeight: isSelected ? 700 : 500,
+    variant: isSelected ? "buttons.primary" : "buttons.secondary",
     textShadow: isSelected ? "0 0 .65px #fff" : null,
-    backgroundColor: isSelected ? colors.polisBlue : colors.lightGray,
-    color: isSelected ? "white" : colors.darkGray,
   }
   return (
-    <button style={buttonStyle} role="tab" aria-selected={isSelected} onClick={onCurateButtonClick}>
+    <Box as="button" ref={ref} sx={buttonStyle} onClick={onCurateButtonClick}>
       {children}
-    </button>
+    </Box>
   )
-}
+})
 
 const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math}) => {
   const GROUP_COUNT = math["group-clusters"].length
   const styles = {
     container: {
       display: "flex",
-      flexDirection: "column",
-      rowGap: 5,
+      flexDirection: ["column-reverse", "row"],
+      gap: "5px",
+      rowGap: "5px",
     },
     groupContainer: {
       display: "flex",
-      gap: 5,
+      flex: [1, "1 1 66.667%"],
+      gap: "5px",
     },
     groupButton: {
       flex: 1,
+    },
+    majorityContainer: {
+      flex: [1, "1 1 33.333%"],
     },
     majorityButton: {
       width: "100%",
@@ -49,26 +47,26 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
   const groups = ['A', 'B', 'C', 'D', 'E']
   
   return(
-    <div style={styles.container} role="tablist">
-      <div style={styles.groupContainer}>
+    <div sx={styles.container}>
+      <div sx={styles.majorityContainer}>
+        <CurateV2Button
+          onCurateButtonClick={() => handleCurateButtonClick(globals.tidCuration.majority)}
+          isSelected={selectedTidCuration === globals.tidCuration.majority}
+          style={styles.majorityButton}
+          children="Diverse Majority Opinion"
+        />
+      </div>
+      <div sx={styles.groupContainer}>
         {groups.slice(0, GROUP_COUNT).map((groupLabel, index) => (
           <CurateV2Button
             key={groupLabel}
             onCurateButtonClick={() => handleCurateButtonClick(index)}
             isSelected={selectedTidCuration === index}
             style={styles.groupButton}
-          >
-            {groupLabel}
-          </CurateV2Button>
+            children={groupLabel}
+          />
         ))}
       </div>
-      <CurateV2Button
-        onCurateButtonClick={() => handleCurateButtonClick(globals.tidCuration.majority)}
-        isSelected={selectedTidCuration === globals.tidCuration.majority}
-        style={styles.majorityButton}
-      >
-        Diverse Majority Opinion
-      </CurateV2Button>
     </div>
   )
 }

--- a/stories/compdem/client-participation/CivicTechTO/CurateV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/CurateV2.js
@@ -2,6 +2,7 @@
 import { jsx, Box } from 'theme-ui'
 
 import React from 'react'
+import * as Tabs from "@radix-ui/react-tabs"
 import * as globals from '../../../../codebases/compdem/client-participation/vis2/components/globals'
 
 export const CurateV2Button = React.forwardRef(({isSelected, handleClick, style, children, ...rest}, ref) => {
@@ -50,27 +51,35 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
   const groups = ['A', 'B', 'C', 'D', 'E']
   
   return(
-    <div sx={styles.container}>
-      <div sx={styles.majorityContainer}>
-        <CurateV2Button
-          handleClick={() => handleCurateButtonClick(globals.tidCuration.majority)}
-          isSelected={selectedTidCuration === globals.tidCuration.majority}
-          style={styles.majorityButton}
-          children="Diverse Majority Opinion"
-        />
-      </div>
-      <div sx={styles.groupContainer}>
-        {groups.slice(0, GROUP_COUNT).map((groupLabel, index) => (
-          <CurateV2Button
-            key={groupLabel}
-            handleClick={() => handleCurateButtonClick(index)}
-            isSelected={selectedTidCuration === index}
-            style={styles.groupButton}
-            children={groupLabel}
-          />
-        ))}
-      </div>
-    </div>
+    // <div>
+      <Tabs.Root defaultValue="group-majority" activationMode="manual">
+        <Tabs.List aria-label="Groups" sx={styles.container}>
+          <div sx={styles.majorityContainer}>
+            <Tabs.Trigger value="group-majority" asChild>
+              <CurateV2Button
+                handleClick={() => handleCurateButtonClick(globals.tidCuration.majority)}
+                isSelected={selectedTidCuration === globals.tidCuration.majority}
+                style={styles.majorityButton}
+                children="Diverse Majority Opinion"
+              />
+            </Tabs.Trigger>
+            </div>
+          <div sx={styles.groupContainer}>
+            {groups.slice(0, GROUP_COUNT).map((groupLabel, index) => (
+              <Tabs.Trigger key={index} value={`group-${index}`} asChild>
+                <CurateV2Button
+                  key={groupLabel}
+                  handleClick={() => handleCurateButtonClick(index)}
+                  isSelected={selectedTidCuration === index}
+                  style={styles.groupButton}
+                  children={groupLabel}
+                />
+              </Tabs.Trigger>
+            ))}
+          </div>
+        </Tabs.List>
+      </Tabs.Root>
+    // </div>
   )
 }
 

--- a/stories/compdem/client-participation/CivicTechTO/CurateV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/CurateV2.js
@@ -32,7 +32,7 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
     },
     groupContainer: {
       display: "flex",
-      flex: [1, "1 1 66.667%"],
+      flex: [1, "1 1 calc(2*100% / 3)"],
       gap: "5px",
     },
     groupButton: {
@@ -40,7 +40,7 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
       flex: 1,
     },
     majorityContainer: {
-      flex: [1, "1 1 33.333%"],
+      flex: [1, "1 1 calc(100% / 3)"],
     },
     majorityButton: {
       height: 35,

--- a/stories/compdem/client-participation/CivicTechTO/CurateV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/CurateV2.js
@@ -22,7 +22,7 @@ export const CurateV2Button = React.forwardRef(({isSelected, handleClick, style,
   )
 })
 
-const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math, isAccessible = false}) => {
+const CurateV2 = React.forwardRef(({selectedTidCuration, handleCurateButtonClick = () => {}, math, isAccessible = false}, ref) => {
   const GROUP_COUNT = math["group-clusters"].length
   const styles = {
     container: {
@@ -53,7 +53,7 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
   return(
     isAccessible 
       ? (
-        <Tabs.Root value={`group-${selectedTidCuration}`} activationMode="manual">
+        <Tabs.Root ref={ref} value={`group-${selectedTidCuration}`} activationMode="manual">
           <Tabs.List aria-label="Groups" sx={styles.container}>
             <div sx={styles.majorityContainer}>
               <Tabs.Trigger value="group-majority" asChild>
@@ -82,7 +82,7 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
         </Tabs.Root>
       )
       : (
-        <div sx={styles.container}>
+        <div ref={ref} sx={styles.container}>
           <div sx={styles.majorityContainer}>
             <CurateV2Button
               handleClick={() => handleCurateButtonClick(globals.tidCuration.majority)}
@@ -105,6 +105,6 @@ const CurateV2 = ({selectedTidCuration, handleCurateButtonClick = () => {}, math
         </div>
       )
   )
-}
+})
 
 export default CurateV2

--- a/stories/compdem/client-participation/CivicTechTO/CurateV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/CurateV2.stories.js
@@ -32,6 +32,7 @@ const Template = ({ groupCount, ...args }) => {
 export const Interactive = Template.bind({})
 Interactive.args = {
   groupCount: 4,
+  isAccessible: true,
   Strings: {
     majorityOpinion: Strings.majorityOpinion,
     group_123: Strings.group_123
@@ -41,6 +42,7 @@ Interactive.args = {
 
 export const Unselected = Template.bind({})
 Unselected.args = {
+  isAccessible: true,
   selectedTidCuration: null,
   Strings: {
     majorityOpinion: Strings.majorityOpinion,

--- a/stories/compdem/client-participation/CivicTechTO/CurateV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/CurateV2.stories.js
@@ -4,11 +4,13 @@ import * as globals from '../../../../codebases/compdem/client-participation/vis
 import Strings from '../../../../codebases/compdem/client-participation/js/strings/en_us'
 import CurateV2 from './CurateV2'
 import { getMath } from '../../../../.storybook/utils'
+import { withParticipationThemeUi } from '../../../../.storybook/decorators'
 
 const mathResults = getMath()
 
 export default {
   component: CurateV2,
+  decorators: [withParticipationThemeUi],
   argTypes: {
     groupCount: {
       options: [2, 3, 4],

--- a/stories/compdem/client-participation/CivicTechTO/ExploreTidV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/ExploreTidV2.js
@@ -1,0 +1,309 @@
+import _ from "lodash";
+import React from "react";
+import * as globals from '../../../../codebases/compdem/client-participation/vis2/components/globals'
+
+const checkmark = "M1299 813l-422 422q-19 19-45 19t-45-19l-294-294q-19-19-19-45t19-45l102-102q19-19 45-19t45 19l147 147 275-275q19-19 45-19t45 19l102 102q19 19 19 45t-19 45zm141 83q0-148-73-273t-198-198-273-73-273 73-198 198-73 273 73 273 198 198 273 73 273-73 198-198 73-273zm224 0q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z";
+const ban = "M1440 893q0-161-87-295l-754 753q137 89 297 89 111 0 211.5-43.5t173.5-116.5 116-174.5 43-212.5zm-999 299l755-754q-135-91-300-91-148 0-273 73t-198 199-73 274q0 162 89 299zm1223-299q0 157-61 300t-163.5 246-245 164-298.5 61-298.5-61-245-164-163.5-246-61-300 61-299.5 163.5-245.5 245-164 298.5-61 298.5 61 245 164 163.5 245.5 61 299.5z";
+
+export const DataSentence = ({math, selectedTidCuration, selectedComment, repfulFor, Strings}) => {
+
+  let markup = null;
+
+  if (_.isNumber(selectedTidCuration)) {
+    const gid = selectedTidCuration;
+    const tid = selectedComment.tid;
+    const groupVotes = math["group-votes"][gid];
+
+    const repness = _.find(math.repness[gid], (r) => { return r.tid === selectedComment.tid })
+    let repfulForAgree = repness["repful-for"] === "agree";
+    const v = groupVotes.votes[tid];
+    const denominator = v.S; // (seen)
+    if (repness["best-agree"] && (v.A > 0)) {
+      repfulForAgree = true;
+    }
+    // const denominator = info.count; // or maybe v.S (seen)
+    // const percent = repfulForAgree ?
+    //   "<i class='fa fa-check-circle-o'></i> " + ((v.A / denominator * 100) >> 0) :
+    //   "<i class='fa fa-ban'></i> " + ((v.D / denominator * 100) >> 0);
+    const percent = repfulForAgree ? ((v.A / denominator * 100) >> 0) : ((v.D / denominator * 100) >> 0);
+
+
+    // var count = repfulForAgree ? v.A : v.D;
+    // var createdString = (new Date(c.get("created") * 1)).toString().match(/(.*?) [0-9]+:/)[1];
+
+    var s = repfulForAgree ? Strings.pctAgreedOfGroupLong : Strings.pctDisagreedOfGroupLong;
+    s = s.replace("{{pct}}", percent);
+    s = s.replace("{{group}}", globals.groupLabels[selectedTidCuration]);
+    s = s.replace("{{comment_id}}", tid);
+
+    markup = (
+      <div style={{display: "flex"}}>
+        <svg height={40} style={{
+            display: "inline",
+            marginRight: 10,
+            fill: repfulForAgree ? globals.colors.agree : globals.colors.disagree
+          }} viewBox="0 0 1792 1792">
+          <path d={repfulForAgree ? checkmark : ban}/>
+          </svg>
+        <p style={{
+            fontSize: 14,
+            fontFamily: "Helvetica",
+            fontWeight: 500,
+            maxWidth: 240,
+            color: "rgb(180,180,180)"
+          }}>
+          {s}
+        </p>
+      </div>
+    )
+  } else if (selectedTidCuration === globals.tidCuration.majority) {
+    const repfulForAgree = _.find(math.consensus.agree, (r) => { return r.tid === selectedComment.tid });
+    const repfulForDisagree = _.find(math.consensus.disagree, (r) => { return r.tid === selectedComment.tid });
+    const repness = repfulForAgree || repfulForDisagree;
+
+    const percent = (repness["n-success"] / repness["n-trials"] * 100) >> 0;
+
+    let s = repfulForAgree ? Strings.pctAgreedLong : Strings.pctDisagreedLong;
+    s = s.replace("{{pct}}", percent);
+    s = s.replace("{{comment_id}}", selectedComment.tid);
+
+    markup = (
+      <div style={{display: "flex"}}>
+        <svg height={40} style={{
+            display: "inline",
+            marginRight: 10,
+            fill: repfulForAgree ? globals.colors.agree : globals.colors.disagree
+          }} viewBox="0 0 1792 1792">
+          <path d={repfulForAgree ? checkmark : ban}/>
+          </svg>
+        <p style={{
+            fontSize: 14,
+            fontFamily: "Helvetica",
+            fontWeight: 500,
+            maxWidth: 240,
+            color: "rgb(180,180,180)"
+          }}>
+          {s}
+        </p>
+      </div>
+    )
+  }
+
+  return markup;
+}
+
+export class ExploreTid extends React.Component {
+
+  handleAgree() {
+    this.props.onVoteClicked({
+      tid: this.props.selectedComment.tid,
+      vote: window.polisTypes.reactions.pull,
+    });
+  }
+  handleDisagree() {
+    this.props.onVoteClicked({
+      tid: this.props.selectedComment.tid,
+      vote: window.polisTypes.reactions.push,
+    });
+  }
+  handlePass() {
+    this.props.onVoteClicked({
+      tid: this.props.selectedComment.tid,
+      vote: window.polisTypes.reactions.pass,
+    });
+  }
+
+  createChangeVotesElements() {
+    let currentVote = null;
+    if (this.props.selectedComment) {
+      let selectedTid = this.props.selectedComment.tid;
+      let voteForSelectedComment = _.find(this.props.votesByMe, (v) => {
+        return v.tid === selectedTid;
+      });
+      currentVote = voteForSelectedComment && voteForSelectedComment.vote;
+    }
+
+    let agreeButton = (
+      <button style={{
+        border: "none",
+        fontSize: 14,
+        backgroundColor: "transparent",
+        fontWeight: "bold",
+        cursor: "pointer",
+      }}
+      onClick={this.handleAgree.bind(this)}>
+      <svg
+        style={{
+          marginRight: 3,
+          position: "relative",
+          top: 2,
+          display: "inline-block"
+        }} fill="rgb(200,0,0)" width="15" viewBox="0 0 1792 1792"><path d="M1299 813l-422 422q-19 19-45 19t-45-19l-294-294q-19-19-19-45t19-45l102-102q19-19 45-19t45 19l147 147 275-275q19-19 45-19t45 19l102 102q19 19 19 45t-19 45zm141 83q0-148-73-273t-198-198-273-73-273 73-198 198-73 273 73 273 198 198 273 73 273-73 198-198 73-273zm224 0q0 209-103 385.5t-279.5 279.5-385.5 103-385.5-103-279.5-279.5-103-385.5 103-385.5 279.5-279.5 385.5-103 385.5 103 279.5 279.5 103 385.5z"/></svg>
+      Agree
+    </button>);
+
+    let disagreeButton = (
+      <button style={{
+        border: "none",
+        fontSize: 14,
+        backgroundColor: "transparent",
+        fontWeight: "bold",
+        cursor: "pointer",
+      }}
+      onClick={this.handleDisagree.bind(this)}>
+        <svg
+          style={{
+            marginRight: 3,
+            position: "relative",
+            top: 2,
+            display: "inline-block"
+          }} fill="rgb(200,0,0)" width="15" viewBox="0 0 1792 1792"><path d="M1440 893q0-161-87-295l-754 753q137 89 297 89 111 0 211.5-43.5t173.5-116.5 116-174.5 43-212.5zm-999 299l755-754q-135-91-300-91-148 0-273 73t-198 199-73 274q0 162 89 299zm1223-299q0 157-61 300t-163.5 246-245 164-298.5 61-298.5-61-245-164-163.5-246-61-300 61-299.5 163.5-245.5 245-164 298.5-61 298.5 61 245 164 163.5 245.5 61 299.5z"/></svg>
+        Disagree
+      </button>
+    );
+
+    let passButton = (
+      <button
+        style={{
+          border: "none",
+          fontSize: 14,
+          backgroundColor: "transparent",
+          fontWeight: "bold",
+          cursor: "pointer",
+        }}
+        onClick={this.handlePass.bind(this)}
+      >
+        Pass
+      </button>
+    );
+
+    // Conditionally show change votes buttons
+    let buttons = null;
+    if (window.preload.firstConv.is_active) {
+      if (!_.isNumber(currentVote)) {
+        buttons = <span>{agreeButton} {disagreeButton} {passButton}</span>
+      } else if (currentVote === window.polisTypes.reactions.pass) {
+        buttons = <span>Change vote: {agreeButton} {disagreeButton}</span>
+      } else if (currentVote === window.polisTypes.reactions.pull) {
+        buttons = <span>Change vote: {disagreeButton} {passButton}</span>
+      } else if (currentVote === window.polisTypes.reactions.push) {
+        buttons = <span>Change vote: {agreeButton} {passButton}</span>
+      }
+    }
+
+    let changeVotesElements = null;
+    if (!_.isNumber(currentVote)) {
+      changeVotesElements = <span> {buttons}</span>
+    } else if (currentVote === window.polisTypes.reactions.pass) {
+      changeVotesElements = <span> You passed. {buttons}</span>
+    } else if (currentVote === window.polisTypes.reactions.pull) {
+      changeVotesElements = <span> You agreed. {buttons}</span>
+    } else if (currentVote === window.polisTypes.reactions.push) {
+      changeVotesElements = <span> You disagreed. {buttons}</span>
+    }
+
+    return (
+      <div style={{display: "flex", justifyContent: "flex-start"}}>
+        {changeVotesElements}
+      </div>
+    )
+  }
+  render() {
+    if (!this.props.selectedComment) {return null}
+    let translatedText = null;
+    if (this.props.selectedComment.translatedText) {
+      let lang = navigator.language;
+      if (lang.indexOf('-') > 0) {
+        lang = lang.split('-')[0];
+        // Do not need undefined check, will just not appear
+        translatedText = this.props.selectedComment.translatedText[lang];
+      }
+    }
+    return (
+      <div style={{
+          borderRadius: 4,
+          padding: "10px 10px 10px 10px",
+          width:"100%",
+          minHeight: 145,
+          textAlign: "left",
+          display: "flex",
+          justifyContent:"center",
+          alignItems: "baseline",
+        }}>
+        <p style={{
+            fontSize: 18,
+            marginRight: 20,
+            fontWeight: "700",
+          }}>
+          {this.props.selectedComment ? "#" + this.props.selectedComment.tid : null}
+        </p>
+        <div style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "space-between",
+            height: "100%",
+          }}>
+          <p style={{
+            width: this.props.browserDimensions > 768 ? 400 : 245,
+            fontSize: 18,
+            fontFamily: "Georgia, serif",
+          }}>
+            {this.props.selectedComment ? this.props.selectedComment.txt : null}
+            {translatedText ? <hr/> : null}
+            {translatedText ? translatedText : null}
+          </p>
+          <DataSentence
+            math={this.props.math}
+            selectedComment={this.props.selectedComment}
+            selectedTidCuration={this.props.selectedTidCuration}
+            Strings={this.props.Strings}
+            />
+          {/*this.createChangeVotesElements()*/}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default ExploreTid;
+
+
+//
+// {/*  <svg
+//     style={{
+//       position: "relative",
+//       top: -2
+//     }}
+//     width={225}
+//     height={70}>
+//     <BarChart
+//       selectedComment={this.props.selectedComment}
+//       allComments={this.props.comments}
+//       groups={window.preload.firstMath["group-votes"]}
+//       />
+//   </svg>
+// */}
+// {/*
+//   <button style={{
+//     border: "none",
+//     backgroundColor: "transparent",
+//     width: 12,
+//     height: 12,
+//     cursor: "pointer",
+//     position: "relative",
+//     right: 8,
+//   }}
+// onClick={this.props.handleReturnToVoteClicked}>
+// <svg
+//   viewPort="0 0 12 12" >
+//     <line x1="1" y1="11"
+//           x2="11" y2="1"
+//           stroke="black"
+//           strokeWidth="2"/>
+//     <line x1="1" y1="1"
+//           x2="11" y2="11"
+//           stroke="black"
+//           strokeWidth="2"/>
+//   </svg>
+// </button>
+// */}

--- a/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
@@ -56,7 +56,7 @@ const SelectionWidgetV2 = ({isStatic, isAccessible, math}) => {
   return (
     <div style={styles.container}>
       <CurateV2
-        {...{ selectedTidCuration, handleCurateButtonClick, math }}
+        {...{ selectedTidCuration, handleCurateButtonClick, math, isAccessible }}
       />
       <TidCarouselComponent
         {...{ selectedTidCuration, selectedComment, handleCommentClick, isAccessible }}

--- a/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
@@ -7,7 +7,7 @@ import { withParticipationThemeUi } from '../../../../.storybook/decorators'
 import TidCarouselV2Animated from './TidCarouselV2Animated'
 import TidCarouselV2Static from './TidCarouselV2Static'
 import CurateV2 from './CurateV2'
-import ExploreTid from '../../../../codebases/compdem/client-participation/vis2/components/exploreTid'
+import ExploreTidV2 from './ExploreTidV2'
 
 const mathResult = getMath()
 const commentsData = getComments()
@@ -64,7 +64,7 @@ const SelectionWidgetV2 = React.forwardRef(({isStatic, isAccessible, math}, ref)
         allComments={commentsData}
         commentsToShow={commentsToShow}
       />
-      <ExploreTid
+      <ExploreTidV2
         math={mathResult}
         selectedComment={selectedComment}
         selectedTidCuration={selectedTidCuration}

--- a/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
@@ -4,7 +4,7 @@ import * as globals from '../../../../codebases/compdem/client-participation/vis
 import Strings from '../../../../codebases/compdem/client-participation/js/strings/en_us'
 import { getMath, getComments } from '../../../../.storybook/utils'
 import { withParticipationThemeUi } from '../../../../.storybook/decorators'
-import TidCarouselV2 from './TidCarouselV2'
+import TidCarouselV2Animated from './TidCarouselV2Animated'
 import TidCarouselV2Static from './TidCarouselV2Static'
 import CurateV2 from './CurateV2'
 import ExploreTid from '../../../../codebases/compdem/client-participation/vis2/components/exploreTid'
@@ -53,7 +53,7 @@ const SelectionWidgetV2 = ({isStatic, math}) => {
       rowGap: 5,
     }
   }
-  const TidCarouselComponent = isStatic ? TidCarouselV2Static : TidCarouselV2
+  const TidCarouselComponent = isStatic ? TidCarouselV2Static : TidCarouselV2Animated
   return (
     <div style={styles.container}>
       <CurateV2

--- a/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
@@ -37,7 +37,7 @@ const SelectionWidgetV2 = ({math}) => {
     setSelectedTidCuration(tidCuration)
   }
 
-  const handleCommentClick = (c) => {
+  const handleCommentClick = (c) => () => {
     setSelectedComment(c)
     action("Clicked")(c)
   }

--- a/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
@@ -4,7 +4,7 @@ import * as globals from '../../../../codebases/compdem/client-participation/vis
 import Strings from '../../../../codebases/compdem/client-participation/js/strings/en_us'
 import { getMath, getComments } from '../../../../.storybook/utils'
 import { withParticipationThemeUi } from '../../../../.storybook/decorators'
-import TidCarouselV2 from './TidCarouselV2'
+import TidCarouselV2Animated from './TidCarouselV2Animated'
 import TidCarouselV2Static from './TidCarouselV2Static'
 import CurateV2 from './CurateV2'
 
@@ -52,7 +52,7 @@ const SelectionWidgetV2 = React.forwardRef(({isStatic, isAccessible, math}, ref)
       rowGap: 5,
     }
   }
-  const TidCarouselComponent = isStatic ? TidCarouselV2Static : TidCarouselV2
+  const TidCarouselComponent = isStatic ? TidCarouselV2Static : TidCarouselV2Animated
   return (
     <div ref={ref} style={styles.container}>
       <CurateV2

--- a/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
@@ -80,6 +80,7 @@ export default {
 const Template = (args) => {
   // TODO: Figure out how to make this sticky at the bottom
   return <div style={{
+    maxWidth: "608px",
   }}>
     <SelectionWidgetV2 {...args} />
   </div>

--- a/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
@@ -11,7 +11,7 @@ import CurateV2 from './CurateV2'
 const mathResult = getMath()
 const commentsData = getComments()
 
-const SelectionWidgetV2 = ({isStatic, math}) => {
+const SelectionWidgetV2 = ({isStatic, isAccessible, math}) => {
   const [selectedTidCuration, setSelectedTidCuration] = useState(globals.tidCuration.majority)
   const [selectedComment, setSelectedComment] = useState(null)
 
@@ -59,7 +59,7 @@ const SelectionWidgetV2 = ({isStatic, math}) => {
         {...{ selectedTidCuration, handleCurateButtonClick, math }}
       />
       <TidCarouselComponent
-        {...{ selectedTidCuration, selectedComment, handleCommentClick }}
+        {...{ selectedTidCuration, selectedComment, handleCommentClick, isAccessible }}
         allComments={commentsData}
         commentsToShow={commentsToShow}
       />
@@ -89,5 +89,6 @@ const Template = (args) => {
 export const Interactive = Template.bind({})
 Interactive.args = {
   isStatic: true,
+  isAccessible: true,
   math: mathResult,
 }

--- a/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
@@ -3,13 +3,15 @@ import { action } from '@storybook/addon-actions'
 import * as globals from '../../../../codebases/compdem/client-participation/vis2/components/globals'
 import Strings from '../../../../codebases/compdem/client-participation/js/strings/en_us'
 import { getMath, getComments } from '../../../../.storybook/utils'
+import { withParticipationThemeUi } from '../../../../.storybook/decorators'
 import TidCarouselV2 from './TidCarouselV2'
+import TidCarouselV2Static from './TidCarouselV2Static'
 import CurateV2 from './CurateV2'
 
 const mathResult = getMath()
 const commentsData = getComments()
 
-const SelectionWidgetV2 = ({math}) => {
+const SelectionWidgetV2 = ({isStatic, math}) => {
   const [selectedTidCuration, setSelectedTidCuration] = useState(globals.tidCuration.majority)
   const [selectedComment, setSelectedComment] = useState(null)
 
@@ -50,12 +52,13 @@ const SelectionWidgetV2 = ({math}) => {
       rowGap: 5,
     }
   }
+  const TidCarouselComponent = isStatic ? TidCarouselV2Static : TidCarouselV2
   return (
     <div style={styles.container}>
       <CurateV2
         {...{ selectedTidCuration, handleCurateButtonClick, math }}
       />
-      <TidCarouselV2
+      <TidCarouselComponent
         {...{ selectedTidCuration, selectedComment, handleCommentClick }}
         allComments={commentsData}
         commentsToShow={commentsToShow}
@@ -66,6 +69,12 @@ const SelectionWidgetV2 = ({math}) => {
 
 export default {
   component: SelectionWidgetV2,
+  decorators: [withParticipationThemeUi],
+  argTypes: {
+    isStatic: {
+      type: "boolean",
+    }
+  }
 }
 
 const Template = (args) => {
@@ -78,5 +87,6 @@ const Template = (args) => {
 
 export const Interactive = Template.bind({})
 Interactive.args = {
+  isStatic: true,
   math: mathResult,
 }

--- a/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/SelectionWidgetV2.stories.js
@@ -11,7 +11,7 @@ import CurateV2 from './CurateV2'
 const mathResult = getMath()
 const commentsData = getComments()
 
-const SelectionWidgetV2 = ({isStatic, isAccessible, math}) => {
+const SelectionWidgetV2 = React.forwardRef(({isStatic, isAccessible, math}, ref) => {
   const [selectedTidCuration, setSelectedTidCuration] = useState(globals.tidCuration.majority)
   const [selectedComment, setSelectedComment] = useState(null)
 
@@ -54,7 +54,7 @@ const SelectionWidgetV2 = ({isStatic, isAccessible, math}) => {
   }
   const TidCarouselComponent = isStatic ? TidCarouselV2Static : TidCarouselV2
   return (
-    <div style={styles.container}>
+    <div ref={ref} style={styles.container}>
       <CurateV2
         {...{ selectedTidCuration, handleCurateButtonClick, math, isAccessible }}
       />
@@ -65,7 +65,7 @@ const SelectionWidgetV2 = ({isStatic, isAccessible, math}) => {
       />
     </div>
   )
-}
+})
 
 export default {
   component: SelectionWidgetV2,

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.js
@@ -87,7 +87,7 @@ const TidCarouselV2 = ({
           containerWidth={bounds.width}
           id={c.tid}
           label={c.tid}
-          handleClick={() => handleCommentClick(c)}
+          handleClick={handleCommentClick(c)}
           isSelected={selectedComment && selectedComment.tid === c.tid}
           isShown={commentsToShowTids.includes(c.tid)}
         />

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.js
@@ -85,7 +85,7 @@ const TidCarouselV2 = ({
       {!bounds.width || allComments.map((c, i) => (
         <TidCarouselButton
           containerWidth={bounds.width}
-          id={c.tid}
+          key={c.tid}
           label={c.tid}
           handleClick={handleCommentClick(c)}
           isSelected={selectedComment && selectedComment.tid === c.tid}

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.js
@@ -26,7 +26,7 @@ export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, con
         onClick={handleClick}
         style={{
           width: style.width,
-          height: 30,
+          height: 25,
           marginRight: style.marginRight,
           // fontSize changes seem slow. Scale span instead.
           // fontSize: style.fontSize,
@@ -75,7 +75,7 @@ const TidCarouselV2 = ({
       display: "flex",
       flex: 1,
       width: "100%",
-      height: 65,
+      height: 55,
       paddingX: 0,
       gap: 5,
       rowGap: 5,

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.js
@@ -62,6 +62,7 @@ const TidCarouselV2 = ({
   handleCommentClick,
   Strings,
 }) => {
+  // TODO: Why doesn't this line avoid infinite renders when null?
   if ( selectedTidCuration === null ) return null
   const [ref, bounds] = useMeasure()
 
@@ -79,6 +80,7 @@ const TidCarouselV2 = ({
       gap: 5,
       rowGap: 5,
       flexWrap: "wrap",
+      justifyContent: "flex-start",
     }}>
       {!bounds.width || allComments.map((c, i) => (
         <TidCarouselButton

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.js
@@ -54,24 +54,26 @@ export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, con
   )
 }
 
-const TidCarouselV2 = ({
+const TidCarouselV2 = React.forwardRef(({
   selectedTidCuration,
   allComments,
   commentsToShow,
   selectedComment,
   handleCommentClick,
   Strings,
-}) => {
+}, ref) => {
   // TODO: Why doesn't this line avoid infinite renders when null?
   if ( selectedTidCuration === null ) return null
-  const [ref, bounds] = useMeasure()
+  // TODO: If we ever need to use the forwardRef, we'll need another package.
+  // See: https://github.com/pmndrs/react-use-measure?tab=readme-ov-file#multiple-refs
+  const [localRef, bounds] = useMeasure()
 
   allComments = allComments.sort((a, b) => a.tid - b.tid)
   const commentsToShowTids = commentsToShow.map(c => c.tid)
 
   // ref not available on first render, so only render map after bounds exists.
   return (
-    <div ref={ref} style={{
+    <div ref={localRef} style={{
       display: "flex",
       flex: 1,
       width: "100%",
@@ -94,6 +96,6 @@ const TidCarouselV2 = ({
       ))}
     </div>
   )
-}
+})
 
 export default TidCarouselV2

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.stories.js
@@ -6,12 +6,13 @@ import TidCarouselV2 from './TidCarouselV2'
 
 const mathResult = getMath()
 const commentsData = getComments()
-commentsData.sort((a,b) => a.tid - b.tid)
 
 export default {
   component: TidCarouselV2,
   argTypes: {
     selectedTidCuration: {
+      // TODO: Figure out why null does infinite renders.
+      // options: [null, 'majority', 0, 1, 2, 3],
       options: ['majority', 0, 1, 2, 3],
       control: { type: 'inline-radio' },
     },

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2.stories.js
@@ -31,7 +31,7 @@ const Template = (args) => {
     }
   )
 
-  const handleCommentClick = (c) => {
+  const handleCommentClick = (c) => () => {
     setSelectedComment(c)
     action("Clicked")(c)
   }

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
@@ -8,7 +8,18 @@ import useMeasure from 'react-use-measure'
 
 const AnimatedBox = animated(Box)
 
+function usePrevious(value) {
+  const ref = React.useRef();
+  React.useEffect(() => {
+    ref.current = value; //assign the value of ref to the argument
+  },[value]); //this code will run when the value of 'value' changes
+  return ref.current; //in the end, return the current ref value.
+}
+
 export const TidCarouselButton = React.forwardRef(({ label, isShown, isSelected, handleClick, containerWidth, style, ...rest }, ref) => {
+  // Allows selected style to persist during transition out.
+  let wasSelected = usePrevious(isSelected)
+
   const styles = {
     button: {
       ...style,
@@ -16,8 +27,10 @@ export const TidCarouselButton = React.forwardRef(({ label, isShown, isSelected,
       overflow: "hidden",
       fontSize: 14,
       letterSpacing: 0.75,
-      variant: isSelected ? "buttons.primary" : "buttons.secondary",
-      textShadow: isSelected ? "0 0 .65px white" : null,
+      // Only want to style based on previous select state when
+      // a button is no longer shown (aka on its was out)
+      variant: (isSelected || (wasSelected && !isShown)) ? "buttons.primary" : "buttons.secondary",
+      textShadow: (isSelected || (wasSelected && !isShown)) ? "0 0 .65px white" : null,
     },
     span: {
       // 1s is rought estimate, but react-spring uses forces, not duration.

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
@@ -54,7 +54,7 @@ export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, con
   )
 }
 
-const TidCarouselV2 = ({
+const TidCarouselV2Animated = ({
   selectedTidCuration,
   allComments,
   commentsToShow,
@@ -96,4 +96,4 @@ const TidCarouselV2 = ({
   )
 }
 
-export default TidCarouselV2
+export default TidCarouselV2Animated

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
@@ -54,7 +54,7 @@ export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, con
   )
 }
 
-const TidCarouselV2 = React.forwardRef(({
+const TidCarouselV2Animated = React.forwardRef(({
   selectedTidCuration,
   allComments,
   commentsToShow,
@@ -98,4 +98,4 @@ const TidCarouselV2 = React.forwardRef(({
   )
 })
 
-export default TidCarouselV2
+export default TidCarouselV2Animated

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
@@ -3,6 +3,26 @@ import { animated, useTransition } from '@react-spring/web'
 import useMeasure from 'react-use-measure'
 
 export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, containerWidth }) => {
+  const styles = {
+    button: {
+      height: 25,
+      padding: 0,
+      border: 0,
+      cursor: "pointer",
+      overflow: "hidden",
+      borderRadius: 4,
+      fontWeight: isSelected ? 700 : 300,
+      backgroundColor: isSelected ? "#03a9f4" : "rgb(235,235,235)",
+      color: isSelected ? "white" : "rgb(0,0,0)",
+    },
+    span: {
+      // 1s is rought estimate, but react-spring uses forces, not duration.
+      transition: "transform 1s ease-in-out",
+      transform: isShown ? "scaleX(1)" : "scaleX(0.5)",
+      // Needed in order to transform.
+      display: "inline-block",
+    },
+  }
   const transition = useTransition(isShown, {
     from: {
       width: 0,
@@ -25,28 +45,14 @@ export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, con
       isShownTransition && <animated.button
         onClick={handleClick}
         style={{
+          ...styles.button,
           width: style.width,
-          height: 25,
           marginRight: style.marginRight,
           // fontSize changes seem slow. Scale span instead.
           // fontSize: style.fontSize,
           opacity: style.opacity,
-          padding: 0,
-          border: 0,
-          cursor: "pointer",
-          overflow: "hidden",
-          borderRadius: 4,
-          fontWeight: isSelected ? 700 : 300,
-          backgroundColor: isSelected ? "#03a9f4" : "rgb(235,235,235)",
-          color: isSelected ? "white" : "rgb(0,0,0)",
         }}>
-        <span style={{
-          // 1s is rought estimate, but react-spring uses forces, not duration.
-          transition: "transform 1s ease-in-out",
-          transform: isShown ? "scaleX(1)" : "scaleX(0.5)",
-          // Needed in order to transform.
-          display: "inline-block",
-        }}>
+        <span style={styles.span}>
           {label}
         </span>
       </animated.button>
@@ -68,9 +74,18 @@ const TidCarouselV2Animated = ({
 
   allComments = allComments.sort((a, b) => a.tid - b.tid)
 
-  // ref not available on first render, so only render map after bounds exists.
-  return (
-    <div ref={ref} style={{
+  const buttonHeight = 25
+  const gap = 5
+  const getRows = cols => {
+    const maxStatements = 10
+    return Math.ceil(maxStatements/cols)
+  }
+  // Example: calc(20%-4px)
+  const getButtonWidthCalc = cols => `calc(${100/cols}% - ${gap*((cols-1)/cols)}px)`
+  const getContainerHeight = cols => buttonHeight*getRows(cols) + gap*(getRows(cols)-1)
+
+  const stylesPrev = {
+    container: {
       display: "flex",
       flex: 1,
       width: "100%",
@@ -80,7 +95,27 @@ const TidCarouselV2Animated = ({
       rowGap: 5,
       flexWrap: "wrap",
       justifyContent: "flex-start",
-    }}>
+    }
+  }
+
+  const styles = {
+    container: {
+      height: getContainerHeight(5),
+      display: "flex",
+      flexWrap: "wrap",
+      gap: `${gap}px`,
+      justifyContent: "flex-start",
+    },
+    button: {
+      // height: buttonHeight,
+      // flex: `1 0 ${getButtonWidthCalc(5)}`,
+      // maxWidth: getButtonWidthCalc(5),
+    },
+  }
+
+  // ref not available on first render, so only render map after bounds exists.
+  return (
+    <div ref={ref} style={stylesPrev.container}>
       {!bounds.width || allComments.map((c, i) => (
         <TidCarouselButton
           containerWidth={bounds.width}

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
@@ -1,6 +1,11 @@
+/** @jsx jsx */
+import { jsx, Box } from 'theme-ui'
+
 import React from 'react'
 import { animated, useTransition } from '@react-spring/web'
 import useMeasure from 'react-use-measure'
+
+const AnimatedBox = animated(Box)
 
 export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, containerWidth, style }) => {
   const styles = {
@@ -30,7 +35,7 @@ export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, con
       opacity: 1,
     },
     enter: {
-      width: containerWidth/5-5,
+      width: containerWidth/5-4,
       marginRight: 0,
       opacity: 1,
     },
@@ -42,20 +47,22 @@ export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, con
   })
   return (
     transition((style, isShownTransition) => (
-      isShownTransition && <animated.button
+      isShownTransition && <AnimatedBox as="button"
         onClick={handleClick}
-        style={{
+        sx={{
           ...styles.button,
+        }}
+        style={{
           width: style.width,
           marginRight: style.marginRight,
           // fontSize changes seem slow. Scale span instead.
           // fontSize: style.fontSize,
           opacity: style.opacity,
         }}>
-        <span style={styles.span}>
+        <span sx={styles.span}>
           {label}
         </span>
-      </animated.button>
+      </AnimatedBox>
     ))
   )
 }
@@ -91,17 +98,19 @@ const TidCarouselV2Animated = ({
       flexWrap: "wrap",
       gap: `${gap}px`,
       justifyContent: "flex-start",
+      marginRight: -30,
     },
     button: {
       height: buttonHeight,
       // flex: `1 0 ${getButtonWidthCalc(5)}`,
-      maxWidth: getButtonWidthCalc(5),
+      // maxWidth: getButtonWidthCalc(5),
     },
   }
 
   // ref not available on first render, so only render map after bounds exists.
   return (
-    <div ref={ref} style={styles.container}>
+    <div ref={ref} style={{overflow: "hidden"}}>
+    <div style={styles.container}>
       {!bounds.width || allComments.map((c, i) => (
         <TidCarouselButton
           style={styles.button}
@@ -113,6 +122,7 @@ const TidCarouselV2Animated = ({
           isShown={commentsToShow.some(cts => cts.tid == c.tid)}
         />
       ))}
+    </div>
     </div>
   )
 }

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
@@ -2,10 +2,10 @@ import React from 'react'
 import { animated, useTransition } from '@react-spring/web'
 import useMeasure from 'react-use-measure'
 
-export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, containerWidth }) => {
+export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, containerWidth, style }) => {
   const styles = {
     button: {
-      height: 25,
+      ...style,
       padding: 0,
       border: 0,
       cursor: "pointer",
@@ -84,20 +84,6 @@ const TidCarouselV2Animated = ({
   const getButtonWidthCalc = cols => `calc(${100/cols}% - ${gap*((cols-1)/cols)}px)`
   const getContainerHeight = cols => buttonHeight*getRows(cols) + gap*(getRows(cols)-1)
 
-  const stylesPrev = {
-    container: {
-      display: "flex",
-      flex: 1,
-      width: "100%",
-      height: 55,
-      paddingX: 0,
-      gap: 5,
-      rowGap: 5,
-      flexWrap: "wrap",
-      justifyContent: "flex-start",
-    }
-  }
-
   const styles = {
     container: {
       height: getContainerHeight(5),
@@ -107,17 +93,18 @@ const TidCarouselV2Animated = ({
       justifyContent: "flex-start",
     },
     button: {
-      // height: buttonHeight,
+      height: buttonHeight,
       // flex: `1 0 ${getButtonWidthCalc(5)}`,
-      // maxWidth: getButtonWidthCalc(5),
+      maxWidth: getButtonWidthCalc(5),
     },
   }
 
   // ref not available on first render, so only render map after bounds exists.
   return (
-    <div ref={ref} style={stylesPrev.container}>
+    <div ref={ref} style={styles.container}>
       {!bounds.width || allComments.map((c, i) => (
         <TidCarouselButton
+          style={styles.button}
           containerWidth={bounds.width}
           key={c.tid}
           label={c.tid}

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
@@ -67,7 +67,6 @@ const TidCarouselV2Animated = ({
   const [ref, bounds] = useMeasure()
 
   allComments = allComments.sort((a, b) => a.tid - b.tid)
-  const commentsToShowTids = commentsToShow.map(c => c.tid)
 
   // ref not available on first render, so only render map after bounds exists.
   return (
@@ -88,8 +87,8 @@ const TidCarouselV2Animated = ({
           key={c.tid}
           label={c.tid}
           handleClick={handleCommentClick(c)}
-          isSelected={selectedComment && selectedComment.tid === c.tid}
-          isShown={commentsToShowTids.includes(c.tid)}
+          isSelected={selectedComment?.tid === c.tid}
+          isShown={commentsToShow.some(cts => cts.tid == c.tid)}
         />
       ))}
     </div>

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.js
@@ -12,13 +12,11 @@ export const TidCarouselButton = ({ label, isShown, isSelected, handleClick, con
     button: {
       ...style,
       padding: 0,
-      border: 0,
-      cursor: "pointer",
       overflow: "hidden",
-      borderRadius: 4,
-      fontWeight: isSelected ? 700 : 300,
-      backgroundColor: isSelected ? "#03a9f4" : "rgb(235,235,235)",
-      color: isSelected ? "white" : "rgb(0,0,0)",
+      fontSize: 14,
+      letterSpacing: 0.75,
+      variant: isSelected ? "buttons.primary" : "buttons.secondary",
+      textShadow: isSelected ? "0 0 .65px white" : null,
     },
     span: {
       // 1s is rought estimate, but react-spring uses forces, not duration.

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.stories.js
@@ -2,13 +2,13 @@ import React from 'react'
 import { action } from '@storybook/addon-actions'
 import Strings from '../../../../codebases/compdem/client-participation/js/strings/en_us'
 import { getComments, getMath } from '../../../../.storybook/utils'
-import TidCarouselV2 from './TidCarouselV2'
+import TidCarouselV2Animated from './TidCarouselV2Animated'
 
 const mathResult = getMath()
 const commentsData = getComments()
 
 export default {
-  component: TidCarouselV2,
+  component: TidCarouselV2Animated,
   argTypes: {
     selectedTidCuration: {
       // TODO: Figure out why null does infinite renders.
@@ -42,7 +42,7 @@ const Template = (args) => {
   if (!commentsToShow.map(c => c.tid).includes(selectedComment?.tid)) {
     handleCommentClick(commentsToShow[0])
   }
-  return <TidCarouselV2 {...args} {...{
+  return <TidCarouselV2Animated {...args} {...{
     handleCommentClick,
     selectedComment,
     commentsToShow,

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.stories.js
@@ -53,6 +53,7 @@ const Template = (args) => {
 
 export const Interactive = Template.bind({})
 Interactive.args = {
+  isAccessible: true,
   selectedTidCuration: 1,
   allComments: commentsData,
   Strings,

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Animated.stories.js
@@ -3,12 +3,14 @@ import { action } from '@storybook/addon-actions'
 import Strings from '../../../../codebases/compdem/client-participation/js/strings/en_us'
 import { getComments, getMath } from '../../../../.storybook/utils'
 import TidCarouselV2Animated from './TidCarouselV2Animated'
+import { withParticipationThemeUi } from '../../../../.storybook/decorators'
 
 const mathResult = getMath()
 const commentsData = getComments()
 
 export default {
   component: TidCarouselV2Animated,
+  decorators: [withParticipationThemeUi],
   argTypes: {
     selectedTidCuration: {
       // TODO: Figure out why null does infinite renders.

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -59,7 +59,7 @@ const TidCarouselV2Static = ({
     isAccessible
       ? (
         <div>
-          <Tabs.Root defaultValue={`statement-${commentsToShowTids[0]}`} activationMode="manual">
+          <Tabs.Root value={`statement-${selectedComment?.tid}`} activationMode="manual">
             <Tabs.List aria-label="Group X Statements" sx={styles.container}>
               {commentsToShowTids.map(tid => (
                 <Tabs.Trigger key={tid} value={`statement-${tid}`} asChild>

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -21,7 +21,7 @@ const TidCarouselButton = React.forwardRef(({ isSelected, handleClick, style, ch
   )
 })
 
-const TidCarouselV2Static = ({
+const TidCarouselV2Static = React.forwardRef(({
   selectedTidCuration,
   // allComments,
   commentsToShow,
@@ -29,7 +29,7 @@ const TidCarouselV2Static = ({
   handleCommentClick,
   isAccessible = false,
   Strings,
-}) => {
+}, ref) => {
   const commentsToShowTids = commentsToShow.map(c => c.tid).sort((a, b) => a - b)
 
   const buttonHeight = 25
@@ -58,7 +58,7 @@ const TidCarouselV2Static = ({
   return (
     isAccessible
       ? (
-        <div>
+        <div ref={ref}>
           <Tabs.Root value={`statement-${selectedComment?.tid}`} activationMode="manual">
             <Tabs.List aria-label="Group X Statements" sx={styles.container}>
               {commentsToShowTids.map(tid => (
@@ -79,7 +79,7 @@ const TidCarouselV2Static = ({
         </div>
       )
       : (
-        <div sx={styles.container}>
+        <div ref={ref} sx={styles.container}>
           {commentsToShowTids.map(tid => (
             <TidCarouselButton
               key={tid}
@@ -92,6 +92,6 @@ const TidCarouselV2Static = ({
         </div>
       )
   )
-}
+})
 
 export default TidCarouselV2Static

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -3,20 +3,20 @@ import { jsx } from 'theme-ui'
 
 import React from "react"
 
-const TidCarouselButton = ({ isSelected, children, handleClick, width, height }) => {
+const TidCarouselButton = ({ isSelected, children, handleClick, widths, height }) => {
   const styles = {
     button: {
+      // variant: isSelected ? "button.primary" : "button.secondary",
       border: 0,
       cursor: "pointer",
       borderRadius: 4,
       fontSize: 14,
       letterSpacing: 0.75,
-      boxSizing: "border-box",
       textShadow: isSelected ? "0 0 .65px white" : null,
       backgroundColor: isSelected ? "polisBlue" : "lightGray",
       color: isSelected ? "white" : "darkGray",
-      flex: `1 0 ${width}`,
-      maxWidth: width,
+      flex: widths.map(w => (`1 0 ${w}`)),
+      maxWidth: widths,
       height: height,
     }
   }
@@ -35,14 +35,16 @@ const TidCarouselV2Static = ({
 
   const buttonHeight = 25
   const gap = 5
-  const cols = 5
-  const maxStatements = 10
-  const rows = Math.ceil(maxStatements/cols)
+  const getRows = cols => {
+    const maxStatements = 10
+    return Math.ceil(maxStatements/cols)
+  }
   // Example: calc(20%-4px)
-  const buttonWidthCalc = `calc(${100/cols}% - ${gap*((cols-1)/cols)}px)`
+  const getButtonWidthCalc = cols => `calc(${100/cols}% - ${gap*((cols-1)/cols)}px)`
+  const getContainerHeight = cols => buttonHeight*getRows(cols) + gap*(getRows(cols)-1)
   const styles = {
     container: {
-      height: buttonHeight*rows + gap*(rows-1),
+      height: [getContainerHeight(5), getContainerHeight(10)],
       display: "flex",
       flexWrap: "wrap", 
       gap: `${gap}px`,
@@ -53,7 +55,7 @@ const TidCarouselV2Static = ({
     <div sx={styles.container}>
       {commentsToShowTids.map(tid => (
         <TidCarouselButton
-          width={buttonWidthCalc}
+          widths={[getButtonWidthCalc(5), getButtonWidthCalc(10)]}
           height={buttonHeight}
           key={tid}
           isSelected={selectedComment?.tid === tid}

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -30,7 +30,7 @@ const TidCarouselV2Static = ({
   handleCommentClick,
   Strings,
 }) => {
-  const commentsToShowTids = commentsToShow.map(c => c.tid)
+  const commentsToShowTids = commentsToShow.map(c => c.tid).sort((a, b) => a - b)
 
   const buttonHeight = 25
   const gap = 5

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -1,26 +1,21 @@
 /** @jsx jsx */
-import { jsx } from 'theme-ui'
+import { jsx, Box } from 'theme-ui'
 
 import React from "react"
 
 const TidCarouselButton = ({ isSelected, children, handleClick, widths, height }) => {
   const styles = {
     button: {
-      // variant: isSelected ? "button.primary" : "button.secondary",
-      border: 0,
-      cursor: "pointer",
-      borderRadius: 4,
       fontSize: 14,
       letterSpacing: 0.75,
+      variant: isSelected ? "buttons.primary" : "buttons.secondary",
       textShadow: isSelected ? "0 0 .65px white" : null,
-      backgroundColor: isSelected ? "polisBlue" : "lightGray",
-      color: isSelected ? "white" : "darkGray",
       flex: widths.map(w => (`1 0 ${w}`)),
       maxWidth: widths,
       height: height,
     }
   }
-  return <button sx={styles.button} onClick={handleClick}>{children}</button>
+  return <Box as="button" sx={styles.button} onClick={handleClick}>{children}</Box>
 }
 
 const TidCarouselV2Static = ({

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -66,8 +66,8 @@ const TidCarouselV2Static = React.forwardRef(({
                   <TidCarouselButton
                     style={styles.button}
                     children={c.tid}
-                    isSelected={selectedComment?.tid === c.tid}
                     handleClick={handleCommentClick(c)}
+                    isSelected={selectedComment?.tid === c.tid}
                   />
                 </Tabs.Trigger>
               ))}
@@ -82,8 +82,8 @@ const TidCarouselV2Static = React.forwardRef(({
         <div ref={ref} sx={styles.container}>
           {commentsToShow.map(c => (
             <TidCarouselButton
-              style={styles.button}
               key={c.tid}
+              style={styles.button}
               children={c.tid}
               handleClick={handleCommentClick(c)}
               isSelected={selectedComment?.tid === c.tid}

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -27,6 +27,7 @@ const TidCarouselV2Static = ({
   commentsToShow,
   selectedComment,
   handleCommentClick,
+  isAccessible = false,
   Strings,
 }) => {
   const commentsToShowTids = commentsToShow.map(c => c.tid).sort((a, b) => a - b)
@@ -55,25 +56,41 @@ const TidCarouselV2Static = ({
     },
   }
   return (
-    <div>
-      <Tabs.Root defaultValue={`statement-${commentsToShowTids[0]}`} activationMode="manual">
-        <Tabs.List aria-label="Group X Statements" sx={styles.container}>
+    isAccessible
+      ? (
+        <div>
+          <Tabs.Root defaultValue={`statement-${commentsToShowTids[0]}`} activationMode="manual">
+            <Tabs.List aria-label="Group X Statements" sx={styles.container}>
+              {commentsToShowTids.map(tid => (
+                <Tabs.Trigger key={tid} value={`statement-${tid}`} asChild>
+                  <TidCarouselButton
+                    style={styles.button}
+                    isSelected={selectedComment?.tid === tid}
+                    handleClick={handleCommentClick(commentsToShow.find(c => c.tid === tid))}
+                    children={tid}
+                  />
+                </Tabs.Trigger>
+              ))}
+            </Tabs.List>
+            {commentsToShowTids.map(tid => (
+              <Tabs.Content key={tid} value={`statement-${tid}`}>Statement {tid}...</Tabs.Content>
+            ))}
+          </Tabs.Root>
+        </div>
+      )
+      : (
+        <div sx={styles.container}>
           {commentsToShowTids.map(tid => (
-            <Tabs.Trigger key={tid} value={`statement-${tid}`} asChild>
-              <TidCarouselButton
-                style={styles.button}
-                isSelected={selectedComment?.tid === tid}
-                handleClick={handleCommentClick(commentsToShow.find(c => c.tid === tid))}
-                children={tid}
-              />
-            </Tabs.Trigger>
+            <TidCarouselButton
+              key={tid}
+              style={styles.button}
+              isSelected={selectedComment?.tid === tid}
+              handleClick={handleCommentClick(commentsToShow.find(c => c.tid === tid))}
+              children={tid}
+            />
           ))}
-        </Tabs.List>
-        {commentsToShowTids.map(tid => (
-          <Tabs.Content key={tid} value={`statement-${tid}`}>Statement {tid}...</Tabs.Content>
-        ))}
-      </Tabs.Root>
-    </div>
+        </div>
+      )
   )
 }
 

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -1,0 +1,71 @@
+import React from "react"
+
+const Button = ({ isSelected, style, children, handleClick }) => {
+  const colors = {
+    polisBlue: "#03a9f4",
+    darkGray: "rgb(100,100,100)",
+    lightGray: "rgb(235,235,235)",
+  }
+  const buttonStyle = {
+    ...style,
+    border: 0,
+    cursor: "pointer",
+    borderRadius: 4,
+    fontSize: 14,
+    // padding: "6px 12px",
+    letterSpacing: 0.75,
+    // fontWeight: isSelected ? 700 : 500,
+    textShadow: isSelected ? "0 0 .65px #fff" : null,
+    backgroundColor: isSelected ? colors.polisBlue : colors.lightGray,
+    color: isSelected ? "white" : colors.darkGray,
+  }
+  return <button style={buttonStyle} onClick={handleClick}>{children}</button>
+}
+
+const TidCarouselV2Static = ({
+  selectedTidCuration,
+  // allComments,
+  commentsToShow,
+  selectedComment,
+  handleCommentClick,
+  Strings,
+}) => {
+  const commentsToShowTids = commentsToShow.map(c => c.tid)
+
+  const buttonHeight = 25
+  const gap = 5
+  const cols = 5
+  // Example: calc(20%-4px)
+  const buttonWidthCalc = `calc(${100/cols}% - ${gap*((cols-1)/cols)}px)`
+  const styles = {
+    container: {
+      height: buttonHeight*2 + gap,
+      display: "flex",
+      flexWrap: "wrap",
+      gap: gap,
+      justifyContent: "flex-start",
+    },
+    button: {
+      flex: `1 0 ${buttonWidthCalc}`,
+      maxWidth: buttonWidthCalc,
+      height: buttonHeight,
+      boxSizing: "border-box",
+    }
+  }
+  return (
+    <div style={styles.container}>
+      {commentsToShowTids.map(tid => (
+        <Button
+          style={styles.button}
+          key={tid}
+          isSelected={selectedComment?.tid === tid}
+          handleClick={handleCommentClick(commentsToShow.find(c => c.tid === tid))}
+        >
+          {tid}
+        </Button>
+      ))}
+    </div>
+  )
+}
+
+export default TidCarouselV2Static

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx, Box } from 'theme-ui'
+import * as Tabs from "@radix-ui/react-tabs"
 
 import React from "react"
 
@@ -54,16 +55,24 @@ const TidCarouselV2Static = ({
     },
   }
   return (
-    <div sx={styles.container}>
-      {commentsToShowTids.map(tid => (
-        <TidCarouselButton
-          key={tid}
-          style={styles.button}
-          isSelected={selectedComment?.tid === tid}
-          handleClick={handleCommentClick(commentsToShow.find(c => c.tid === tid))}
-          children={tid}
-        />
-      ))}
+    <div>
+      <Tabs.Root defaultValue={`statement-${commentsToShowTids[0]}`} activationMode="manual">
+        <Tabs.List aria-label="Group X Statements" sx={styles.container}>
+          {commentsToShowTids.map(tid => (
+            <Tabs.Trigger key={tid} value={`statement-${tid}`} asChild>
+              <TidCarouselButton
+                style={styles.button}
+                isSelected={selectedComment?.tid === tid}
+                handleClick={handleCommentClick(commentsToShow.find(c => c.tid === tid))}
+                children={tid}
+              />
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+        {commentsToShowTids.map(tid => (
+          <Tabs.Content key={tid} value={`statement-${tid}`}>Statement {tid}...</Tabs.Content>
+        ))}
+      </Tabs.Root>
     </div>
   )
 }

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -1,25 +1,26 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+
 import React from "react"
 
-const Button = ({ isSelected, style, children, handleClick }) => {
-  const colors = {
-    polisBlue: "#03a9f4",
-    darkGray: "rgb(100,100,100)",
-    lightGray: "rgb(235,235,235)",
+const TidCarouselButton = ({ isSelected, children, handleClick, width, height }) => {
+  const styles = {
+    button: {
+      border: 0,
+      cursor: "pointer",
+      borderRadius: 4,
+      fontSize: 14,
+      letterSpacing: 0.75,
+      boxSizing: "border-box",
+      textShadow: isSelected ? "0 0 .65px white" : null,
+      backgroundColor: isSelected ? "polisBlue" : "lightGray",
+      color: isSelected ? "white" : "darkGray",
+      flex: `1 0 ${width}`,
+      maxWidth: width,
+      height: height,
+    }
   }
-  const buttonStyle = {
-    ...style,
-    border: 0,
-    cursor: "pointer",
-    borderRadius: 4,
-    fontSize: 14,
-    // padding: "6px 12px",
-    letterSpacing: 0.75,
-    // fontWeight: isSelected ? 700 : 500,
-    textShadow: isSelected ? "0 0 .65px #fff" : null,
-    backgroundColor: isSelected ? colors.polisBlue : colors.lightGray,
-    color: isSelected ? "white" : colors.darkGray,
-  }
-  return <button style={buttonStyle} onClick={handleClick}>{children}</button>
+  return <button sx={styles.button} onClick={handleClick}>{children}</button>
 }
 
 const TidCarouselV2Static = ({
@@ -35,34 +36,30 @@ const TidCarouselV2Static = ({
   const buttonHeight = 25
   const gap = 5
   const cols = 5
+  const maxStatements = 10
+  const rows = Math.ceil(maxStatements/cols)
   // Example: calc(20%-4px)
   const buttonWidthCalc = `calc(${100/cols}% - ${gap*((cols-1)/cols)}px)`
   const styles = {
     container: {
-      height: buttonHeight*2 + gap,
+      height: buttonHeight*rows + gap*(rows-1),
       display: "flex",
-      flexWrap: "wrap",
-      gap: gap,
+      flexWrap: "wrap", 
+      gap: `${gap}px`,
       justifyContent: "flex-start",
     },
-    button: {
-      flex: `1 0 ${buttonWidthCalc}`,
-      maxWidth: buttonWidthCalc,
-      height: buttonHeight,
-      boxSizing: "border-box",
-    }
   }
   return (
-    <div style={styles.container}>
+    <div sx={styles.container}>
       {commentsToShowTids.map(tid => (
-        <Button
-          style={styles.button}
+        <TidCarouselButton
+          width={buttonWidthCalc}
+          height={buttonHeight}
           key={tid}
           isSelected={selectedComment?.tid === tid}
           handleClick={handleCommentClick(commentsToShow.find(c => c.tid === tid))}
-        >
-          {tid}
-        </Button>
+          children={tid}
+        />
       ))}
     </div>
   )

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -3,19 +3,21 @@ import { jsx, Box } from 'theme-ui'
 
 import React from "react"
 
-const TidCarouselButton = React.forwardRef(({ isSelected, children, handleClick, widths, height, ...rest }, ref) => {
+const TidCarouselButton = React.forwardRef(({ isSelected, handleClick, style, children, ...rest }, ref) => {
   const styles = {
     button: {
+      ...style,
       fontSize: 14,
       letterSpacing: 0.75,
       variant: isSelected ? "buttons.primary" : "buttons.secondary",
       textShadow: isSelected ? "0 0 .65px white" : null,
-      flex: widths.map(w => (`1 0 ${w}`)),
-      maxWidth: widths,
-      height: height,
     }
   }
-  return <Box ref={ref} as="button" sx={styles.button} onClick={handleClick} {...rest}>{children}</Box>
+  return (
+    <Box as="button" ref={ref} sx={styles.button} onClick={handleClick} {...rest}>
+      {children}
+    </Box>
+  )
 })
 
 const TidCarouselV2Static = ({
@@ -45,14 +47,18 @@ const TidCarouselV2Static = ({
       gap: `${gap}px`,
       justifyContent: "flex-start",
     },
+    button: {
+      height: buttonHeight,
+      flex: [`1 0 ${getButtonWidthCalc(5)}`, `1 0 ${getButtonWidthCalc(10)}`],
+      maxWidth: [getButtonWidthCalc(5), getButtonWidthCalc(10)],
+    },
   }
   return (
     <div sx={styles.container}>
       {commentsToShowTids.map(tid => (
         <TidCarouselButton
           key={tid}
-          widths={[getButtonWidthCalc(5), getButtonWidthCalc(10)]}
-          height={buttonHeight}
+          style={styles.button}
           isSelected={selectedComment?.tid === tid}
           handleClick={handleCommentClick(commentsToShow.find(c => c.tid === tid))}
           children={tid}

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -3,7 +3,7 @@ import { jsx, Box } from 'theme-ui'
 
 import React from "react"
 
-const TidCarouselButton = ({ isSelected, children, handleClick, widths, height }) => {
+const TidCarouselButton = React.forwardRef(({ isSelected, children, handleClick, widths, height, ...rest }, ref) => {
   const styles = {
     button: {
       fontSize: 14,
@@ -15,8 +15,8 @@ const TidCarouselButton = ({ isSelected, children, handleClick, widths, height }
       height: height,
     }
   }
-  return <Box as="button" sx={styles.button} onClick={handleClick}>{children}</Box>
-}
+  return <Box ref={ref} as="button" sx={styles.button} onClick={handleClick} {...rest}>{children}</Box>
+})
 
 const TidCarouselV2Static = ({
   selectedTidCuration,
@@ -50,9 +50,9 @@ const TidCarouselV2Static = ({
     <div sx={styles.container}>
       {commentsToShowTids.map(tid => (
         <TidCarouselButton
+          key={tid}
           widths={[getButtonWidthCalc(5), getButtonWidthCalc(10)]}
           height={buttonHeight}
-          key={tid}
           isSelected={selectedComment?.tid === tid}
           handleClick={handleCommentClick(commentsToShow.find(c => c.tid === tid))}
           children={tid}

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.js
@@ -28,7 +28,7 @@ const TidCarouselV2Static = ({
   handleCommentClick,
   Strings,
 }) => {
-  const commentsToShowTids = commentsToShow.map(c => c.tid).sort((a, b) => a - b)
+  commentsToShow.sort((a, b) => a.tid - b.tid)
 
   const buttonHeight = 25
   const gap = 5
@@ -55,13 +55,13 @@ const TidCarouselV2Static = ({
   }
   return (
     <div sx={styles.container}>
-      {commentsToShowTids.map(tid => (
+      {commentsToShow.map((c, i) => (
         <TidCarouselButton
-          key={tid}
           style={styles.button}
-          isSelected={selectedComment?.tid === tid}
-          handleClick={handleCommentClick(commentsToShow.find(c => c.tid === tid))}
-          children={tid}
+          key={c.tid}
+          children={c.tid}
+          handleClick={handleCommentClick(c)}
+          isSelected={selectedComment?.tid === c.tid}
         />
       ))}
     </div>

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.stories.js
@@ -1,0 +1,99 @@
+import React, { useState } from 'react'
+import { action } from '@storybook/addon-actions'
+import TidCarouselV2Static from './TidCarouselV2Static'
+import * as globals from '../../../../codebases/compdem/client-participation/vis2/components/globals'
+import Strings from '../../../../codebases/compdem/client-participation/js/strings/en_us'
+import { getMath, getComments } from '../../../../.storybook/utils'
+
+const mathResults = getMath()
+const commentsData = getComments()
+
+export default {
+  component: TidCarouselV2Static,
+}
+
+const Template = (args) => {
+  const [selectedComment, setSelectedComment] = useState(null)
+
+  const handleCommentClick = (comment) => () => {
+    action("Clicked")(comment)
+    setSelectedComment(comment)
+  }
+
+  const commentsByGroup = Object.assign({},
+    mathResults.repness,
+    {
+      "majority": [
+        ...mathResults.consensus.agree,
+        ...mathResults.consensus.disagree,
+      ],
+    }
+  )
+  const commentsToShow = commentsData
+    .filter(c => commentsByGroup[args.selectedTidCuration]
+      ?.map(i => i.tid).includes(c.tid)
+    )
+
+  return <TidCarouselV2Static {...{
+    handleCommentClick,
+    selectedComment,
+    commentsToShow
+  }} {...args} />
+}
+
+export const Interactive = Template.bind({})
+Interactive.args = {
+  selectedTidCuration: 0,
+  Strings,
+}
+Interactive.argTypes = {
+  selectedTidCuration: {
+    options: [null, 'majority', 0, 1, 2, 3],
+    control: { type: 'inline-radio' },
+  },
+}
+
+export const Empty = Template.bind({})
+Empty.args = {
+  commentsToShow: [],
+  selectedTidCuration: null,
+  selectedComment: null,
+  // TODO: Pretty sure this is janky. It should be simply action("Clicked")
+  // and the prop in tidCarousel should be:
+  // onClick={() => this.props.handleCommentClick(c)}
+  // not just
+  // onClick={this.props.handleCommentClick(c)}
+  handleCommentClick: (c) => () => action("Clicked")(c),
+  Strings,
+}
+
+export const OneStatement = Template.bind({})
+OneStatement.args = {
+  ...Empty.args,
+  commentsToShow: commentsData.slice(10,11),
+}
+
+export const FullFirstRow = Template.bind({})
+FullFirstRow.args = {
+  ...Empty.args,
+  commentsToShow: commentsData.slice(10,15),
+}
+
+export const StartSecondRow = Template.bind({})
+StartSecondRow.args = {
+  ...Empty.args,
+  commentsToShow: commentsData.slice(10,16),
+}
+
+export const FullSecondRow = Template.bind({})
+FullSecondRow.args = {
+  ...Empty.args,
+  commentsToShow: commentsData.slice(10,20),
+}
+
+export const Selected = Template.bind({})
+Selected.args = {
+  ...Empty.args,
+  commentsToShow: commentsData.slice(10,20),
+  selectedComment: commentsData[11],
+}

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.stories.js
@@ -8,6 +8,20 @@ import { getMath, getComments } from '../../../../.storybook/utils'
 const mathResults = getMath()
 const commentsData = getComments()
 
+const pluckNBetweenLowerUpper = (n, lower, upper) => {
+  let numbers = []
+  while (numbers.length < n) {
+    let candidate = Math.floor(Math.random() * (upper - lower)) + (lower + 1)
+    if (!numbers.includes(candidate)) {
+      numbers.push(candidate)
+    }
+  }
+  // Ascending integer sort.
+  numbers.sort((a, b) => a - b)
+
+  return numbers
+}
+
 export default {
   component: TidCarouselV2Static,
 }
@@ -73,20 +87,20 @@ OneStatement.args = {
   commentsToShow: commentsData.slice(10,11),
 }
 
-export const FullFirstRow = Template.bind({})
-FullFirstRow.args = {
+export const FiveStatements = Template.bind({})
+FiveStatements.args = {
   ...Empty.args,
   commentsToShow: commentsData.slice(10,15),
 }
 
-export const StartSecondRow = Template.bind({})
-StartSecondRow.args = {
+export const SixStatements = Template.bind({})
+SixStatements.args = {
   ...Empty.args,
   commentsToShow: commentsData.slice(10,16),
 }
 
-export const FullSecondRow = Template.bind({})
-FullSecondRow.args = {
+export const TenStatements = Template.bind({})
+TenStatements.args = {
   ...Empty.args,
   commentsToShow: commentsData.slice(10,20),
 }
@@ -96,4 +110,16 @@ Selected.args = {
   ...Empty.args,
   commentsToShow: commentsData.slice(10,20),
   selectedComment: commentsData[11],
+}
+
+export const UpToDoubleDigits = Template.bind({})
+UpToDoubleDigits.args = {
+  ...Empty.args,
+  commentsToShow: pluckNBetweenLowerUpper(10, 0, 100).map(i => ({ tid: i })),
+}
+
+export const UpToTripleDigits = Template.bind({})
+UpToTripleDigits.args = {
+  ...Empty.args,
+  commentsToShow: pluckNBetweenLowerUpper(10, 0, 400).map(i => ({ tid: i })),
 }

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.stories.js
@@ -59,6 +59,7 @@ const Template = (args) => {
 
 export const Interactive = Template.bind({})
 Interactive.args = {
+  isAccessible: true,
   selectedTidCuration: 0,
   Strings,
 }
@@ -71,6 +72,7 @@ Interactive.argTypes = {
 
 export const Empty = Template.bind({})
 Empty.args = {
+  isAccessible: true,
   commentsToShow: [],
   selectedTidCuration: null,
   selectedComment: null,

--- a/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.stories.js
+++ b/stories/compdem/client-participation/CivicTechTO/TidCarouselV2Static.stories.js
@@ -4,6 +4,7 @@ import TidCarouselV2Static from './TidCarouselV2Static'
 import * as globals from '../../../../codebases/compdem/client-participation/vis2/components/globals'
 import Strings from '../../../../codebases/compdem/client-participation/js/strings/en_us'
 import { getMath, getComments } from '../../../../.storybook/utils'
+import { withParticipationThemeUi } from '../../../../.storybook/decorators'
 
 const mathResults = getMath()
 const commentsData = getComments()
@@ -24,6 +25,7 @@ const pluckNBetweenLowerUpper = (n, lower, upper) => {
 
 export default {
   component: TidCarouselV2Static,
+  decorators: [withParticipationThemeUi],
 }
 
 const Template = (args) => {

--- a/stories/compdem/client-participation/TidCarousel.stories.js
+++ b/stories/compdem/client-participation/TidCarousel.stories.js
@@ -7,7 +7,6 @@ import { getMath, getComments } from '../../../.storybook/utils'
 
 const mathResults = getMath()
 const commentsData = getComments()
-commentsData.sort((a,b) => a.tid - b.tid)
 
 const pluckNBetweenLowerUpper = (n, lower, upper) => {
   let numbers = []
@@ -25,12 +24,6 @@ const pluckNBetweenLowerUpper = (n, lower, upper) => {
 
 export default {
   component: TidCarousel,
-  argTypes: {
-    selectedTidCuration: {
-      options: [null, "majority", 0, 1, 2, 3],
-      control: { type: 'inline-radio' },
-    },
-  },
 }
 
 const Template = (args) => {
@@ -66,10 +59,16 @@ Interactive.args = {
   selectedTidCuration: 0,
   Strings,
 }
+Interactive.argTypes = {
+  selectedTidCuration: {
+    options: [null, "majority", 0, 1, 2, 3],
+    control: { type: 'inline-radio' },
+  },
+}
 
 export const Default = Template.bind({})
 Default.args = {
-  selectedTidCuration: 1,
+  selectedTidCuration: undefined,
   commentsToShow: commentsData.slice(10,20),
   selectedComment: null,
   // TODO: Pretty sure this is janky. It should be simply action("Clicked")
@@ -79,6 +78,12 @@ Default.args = {
   // onClick={this.props.handleCommentClick(c)}
   handleCommentClick: (c) => () => action("Clicked")(c),
   Strings,
+}
+
+export const Hidden = Template.bind({})
+Hidden.args = {
+  ...Default.args,
+  selectedTidCuration: null,
 }
 
 // TODO: Load dataset with hundreds/thousands of comments.

--- a/stories/compdem/client-participation/TidCarousel.stories.js
+++ b/stories/compdem/client-participation/TidCarousel.stories.js
@@ -54,7 +54,11 @@ const Template = (args) => {
       ?.map(i => i.tid).includes(c.tid)
     )
 
-  return <TidCarousel {...{handleCommentClick, selectedComment, commentsToShow}} {...args} />
+  return <TidCarousel {...{
+    handleCommentClick,
+    selectedComment,
+    commentsToShow
+  }} {...args} />
 }
 
 export const Interactive = Template.bind({})

--- a/stories/compdem/client-participation/TidCarousel.stories.js
+++ b/stories/compdem/client-participation/TidCarousel.stories.js
@@ -6,7 +6,7 @@ import Strings from '../../../codebases/compdem/client-participation/js/strings/
 import { getMath, getComments } from '../../../.storybook/utils'
 
 const mathResults = getMath()
-const commentsData = getComments()
+const commentsData = getComments().sort((a, b) => a.tid - b.tid)
 
 const pluckNBetweenLowerUpper = (n, lower, upper) => {
   let numbers = []
@@ -18,7 +18,7 @@ const pluckNBetweenLowerUpper = (n, lower, upper) => {
   }
   // Ascending integer sort.
   numbers.sort((a, b) => a - b)
-  
+
   return numbers
 }
 
@@ -80,10 +80,49 @@ Default.args = {
   Strings,
 }
 
-export const Hidden = Template.bind({})
-Hidden.args = {
-  ...Default.args,
-  selectedTidCuration: null,
+export const Empty = Template.bind({})
+Empty.args = {
+  commentsToShow: [],
+  selectedTidCuration: globals.tidCuration.majority,
+  selectedComment: null,
+  // TODO: Pretty sure this is janky. It should be simply action("Clicked")
+  // and the prop in tidCarousel should be:
+  // onClick={() => this.props.handleCommentClick(c)}
+  // not just
+  // onClick={this.props.handleCommentClick(c)}
+  handleCommentClick: (c) => () => action("Clicked")(c),
+  Strings,
+}
+
+export const OneStatement = Template.bind({})
+OneStatement.args = {
+  ...Empty.args,
+  commentsToShow: pluckNBetweenLowerUpper(1, 0, 25).map(i => ({ tid: i })),
+}
+
+export const FiveStatements = Template.bind({})
+FiveStatements.args = {
+  ...Empty.args,
+  commentsToShow: pluckNBetweenLowerUpper(5, 0, 25).map(i => ({ tid: i })),
+}
+
+export const SixStatements = Template.bind({})
+SixStatements.args = {
+  ...Empty.args,
+  commentsToShow: pluckNBetweenLowerUpper(6, 0, 25).map(i => ({ tid: i })),
+}
+
+export const TenStatements = Template.bind({})
+TenStatements.args = {
+  ...Empty.args,
+  commentsToShow: pluckNBetweenLowerUpper(10, 0, 25).map(i => ({ tid: i })),
+}
+
+export const Selected = Template.bind({})
+Selected.args = {
+  ...Empty.args,
+  commentsToShow: commentsData.slice(10,20),
+  selectedComment: commentsData[11],
 }
 
 // TODO: Load dataset with hundreds/thousands of comments.
@@ -93,31 +132,23 @@ Hidden.args = {
 //  commentsToShow: commentsData.slice(95,105),
 //}
 
-export const StatementSelected = Template.bind({})
-StatementSelected.args = {
-  ...Default.args,
-  selectedComment: { tid: commentsData[11].tid }
-}
-
-export const FewStatements = Template.bind({})
-FewStatements.args = {
-  ...Default.args,
-  commentsToShow: commentsData.slice(10,15),
-}
-
-export const Pagination = Template.bind({})
-Pagination.args = {
-  ...Default.args,
-  commentsToShow: commentsData.slice(10,40),
-}
+// export const Pagination = Template.bind({})
+// Pagination.args = {
+//   ...Default.args,
+//   commentsToShow: commentsData.slice(10,40),
+// }
 
 export const UpToDoubleDigits = Template.bind({})
 UpToDoubleDigits.args = {
   ...Default.args,
-  commentsToShow: [
-    ...pluckNBetweenLowerUpper(10, 0, commentsData.length-1).map(i => commentsData[i])
-  ]
-} 
+  commentsToShow: pluckNBetweenLowerUpper(10, 0, 100).map(i => ({ tid: i })),
+}
+
+export const UpToTripleDigits = Template.bind({})
+UpToTripleDigits.args = {
+  ...Default.args,
+  commentsToShow: pluckNBetweenLowerUpper(10, 0, 400).map(i => ({ tid: i })),
+}
 
 export const NoGroupSelectedSoHidden = Template.bind({})
 NoGroupSelectedSoHidden.args = {


### PR DESCRIPTION
This works towards making hte V2 selection components more accessible, part of https://github.com/CivicTechTO/polis-storybook/issues/4

This builds on https://github.com/CivicTechTO/polis-storybook/pull/16

It add `isAccessible` flags to the relevant components, so that the impact of the changes can be easily reviewed

Demo: https://civictechto.github.io/polis-storybook/PR-17/?path=/story/compdem-client-participation-civictechto-selectionwidgetv2--interactive&globals=viewport:mobile1